### PR TITLE
Adding sensitive_params option

### DIFF
--- a/bespin/operations/deployer.py
+++ b/bespin/operations/deployer.py
@@ -61,7 +61,8 @@ class Deployer(object):
             self.suspend_cloudformation_actions(stack)
 
         sys.stdout.write("Building - {0}\n".format(stack.stack_name))
-        sys.stdout.write(json.dumps(stack.params_json_obj, indent=4))
+        params_no_echo = [self.mask_params(c,stack.sensitive_params) for c in stack.params_json_obj]
+        sys.stdout.write(json.dumps(params_no_echo , indent=4))
         sys.stdout.write("\n")
         sys.stdout.flush()
 
@@ -92,6 +93,13 @@ class Deployer(object):
         if stack.suspend_actions:
             self.resume_cloudformation_actions(stack)
 
+    def mask_params(self, params_json, sensitive_params):
+        maskparams=json.loads(json.dumps(params_json))
+        for sensitive_param in sensitive_params:   
+            if maskparams['ParameterKey'] == sensitive_param:
+               maskparams['ParameterValue'] = 'XXXXXXXXXXXX'
+        return maskparams
+
     def confirm_deployment(self, stack, start=None):
         """Confirm our deployment"""
         stack.confirm_the_deployment(start=start)
@@ -107,4 +115,3 @@ class Deployer(object):
         asg_physical_id = stack.physical_id_for(stack.auto_scaling_group_name)
         stack.ec2.resume_processes(asg_physical_id)
         log.info("Resumed Processes on AutoScaling Group %s", asg_physical_id)
-

--- a/bespin/option_spec/bespin_specs.py
+++ b/bespin/option_spec/bespin_specs.py
@@ -383,7 +383,7 @@ class BespinSpec(object):
                 ))
 
             , confirm_deployment = optional_spec(self.confirm_deployment_spec)
-            , sensitive_params = optional_spec(listof(string_spec()))
+            , sensitive_params = defaulted(listof(string_spec()), ["Password"])
             )
 
     @memoized_property
@@ -413,3 +413,4 @@ class BespinSpec(object):
 
             , extra_imports = listof(imports.import_spec())
             )
+

--- a/bespin/option_spec/bespin_specs.py
+++ b/bespin/option_spec/bespin_specs.py
@@ -383,6 +383,7 @@ class BespinSpec(object):
                 ))
 
             , confirm_deployment = optional_spec(self.confirm_deployment_spec)
+            , sensitive_params = optional_spec(listof(string_spec()))
             )
 
     @memoized_property
@@ -412,4 +413,3 @@ class BespinSpec(object):
 
             , extra_imports = listof(imports.import_spec())
             )
-

--- a/bespin/option_spec/stack_objs.py
+++ b/bespin/option_spec/stack_objs.py
@@ -92,6 +92,8 @@ class Stack(dictobj):
         , "netscaler": "Netscaler declaration"
         , "stackdriver": "Stackdriver options used for giving events to stackdriver"
         , "notify_stackdriver": "Whether to notify stackdriver about deploying the cloudformation"
+
+        , "sensitive_params": "Used to hide sensitive values during build"
         }
 
     def __repr__(self):


### PR DESCRIPTION
This will allow user to mask sensitive values during build

sample bespin.yml file
`...`
`sensitive_params:`
`- Username`
`- Password`
`...`

Output
`[`
`    {`
`        "ParameterValue": "XXXXXXXXXXXX",`
`        "ParameterKey": "Username"`
`    },`
` ... omitted...`
`    {`
`        "ParameterValue": "XXXXXXXXXXXX",`
`        "ParameterKey": "Password"`
`    },`
` ... omitted...`
`]`

